### PR TITLE
Add supabase task list scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ lib/
 
 ---
 
+## 🚧 État actuel du projet
+
+Cette version fournit une base fonctionnelle comprenant :
+
+- l'initialisation de Supabase via `SupabaseService` ;
+- la gestion d'une liste de tâches persistée dans la table `tasks` ;
+- un écran d'accueil permettant d'afficher et d'ajouter des tâches avec Riverpod.
+
+---
+
 ## 🔧 Installation locale
 
 ### 1. Prérequis

--- a/README_MEMOVOX.md
+++ b/README_MEMOVOX.md
@@ -50,6 +50,16 @@ lib/
 
 ---
 
+## 🚧 État actuel du projet
+
+Cette version fournit une base fonctionnelle comprenant :
+
+- l'initialisation de Supabase via `SupabaseService` ;
+- la gestion d'une liste de tâches persistée dans la table `tasks` ;
+- un écran d'accueil permettant d'afficher et d'ajouter des tâches avec Riverpod.
+
+---
+
 ## 🔧 Installation locale
 
 ### 1. Prérequis

--- a/lib/core/env.dart
+++ b/lib/core/env.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+class Env {
+  static String get supabaseUrl => dotenv.env['SUPABASE_URL'] ?? '';
+  static String get supabaseAnonKey => dotenv.env['SUPABASE_ANON_KEY'] ?? '';
+
+  static Future<void> load() async {
+    await dotenv.load(fileName: '.env');
+  }
+}

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../tasks/task_controller.dart';
+import '../tasks/task.dart';
+
+class HomePage extends ConsumerWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tasksAsync = ref.watch(tasksProvider);
+    final textController = TextEditingController();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('MemoVox')),
+      body: tasksAsync.when(
+        data: (tasks) => Column(
+          children: [
+            Expanded(
+              child: ListView.builder(
+                itemCount: tasks.length,
+                itemBuilder: (context, index) {
+                  final task = tasks[index];
+                  return ListTile(
+                    title: Text(task.title),
+                    leading: Checkbox(
+                      value: task.completed,
+                      onChanged: (_) => ref.read(tasksProvider.notifier).toggle(task),
+                    ),
+                  );
+                },
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: textController,
+                      decoration: const InputDecoration(labelText: 'Nouvelle tâche'),
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.add),
+                    onPressed: () {
+                      final text = textController.text.trim();
+                      if (text.isNotEmpty) {
+                        ref.read(tasksProvider.notifier).addTask(text);
+                        textController.clear();
+                      }
+                    },
+                  )
+                ],
+              ),
+            )
+          ],
+        ),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Erreur: $e')),
+      ),
+    );
+  }
+}

--- a/lib/features/tasks/task.dart
+++ b/lib/features/tasks/task.dart
@@ -1,0 +1,23 @@
+class Task {
+  final String id;
+  final String title;
+  final bool completed;
+
+  Task({required this.id, required this.title, this.completed = false});
+
+  factory Task.fromMap(Map<String, dynamic> map) {
+    return Task(
+      id: map['id'] as String,
+      title: map['title'] as String,
+      completed: map['completed'] as bool? ?? false,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'title': title,
+      'completed': completed,
+    };
+  }
+}

--- a/lib/features/tasks/task_controller.dart
+++ b/lib/features/tasks/task_controller.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'task.dart';
+import 'task_repository.dart';
+
+final taskRepositoryProvider = Provider<TaskRepository>((ref) {
+  return TaskRepository();
+});
+
+final tasksProvider = StateNotifierProvider<TasksNotifier, AsyncValue<List<Task>>>((ref) {
+  final repo = ref.watch(taskRepositoryProvider);
+  return TasksNotifier(repo)..loadTasks();
+});
+
+class TasksNotifier extends StateNotifier<AsyncValue<List<Task>>> {
+  final TaskRepository _repository;
+  TasksNotifier(this._repository) : super(const AsyncValue.loading());
+
+  Future<void> loadTasks() async {
+    try {
+      final tasks = await _repository.getTasks();
+      state = AsyncValue.data(tasks);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  Future<void> addTask(String title) async {
+    await _repository.addTask(title);
+    await loadTasks();
+  }
+
+  Future<void> toggle(Task task) async {
+    await _repository.toggleTask(task);
+    await loadTasks();
+  }
+}

--- a/lib/features/tasks/task_repository.dart
+++ b/lib/features/tasks/task_repository.dart
@@ -1,0 +1,21 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'task.dart';
+import '../../services/supabase_service.dart';
+
+class TaskRepository {
+  final SupabaseClient _client = SupabaseService().client;
+
+  Future<List<Task>> getTasks() async {
+    final response = await _client.from('tasks').select();
+    final data = response as List<dynamic>;
+    return data.map((e) => Task.fromMap(e as Map<String, dynamic>)).toList();
+  }
+
+  Future<void> addTask(String title) async {
+    await _client.from('tasks').insert({'title': title});
+  }
+
+  Future<void> toggleTask(Task task) async {
+    await _client.from('tasks').update({'completed': !task.completed}).eq('id', task.id);
+  }
+}

--- a/lib/features/voice/voice_service.dart
+++ b/lib/features/voice/voice_service.dart
@@ -1,0 +1,27 @@
+import 'package:speech_to_text/speech_to_text.dart';
+import 'package:flutter_tts/flutter_tts.dart';
+
+class VoiceService {
+  final SpeechToText _speech = SpeechToText();
+  final FlutterTts _tts = FlutterTts();
+
+  Future<bool> init() async {
+    return _speech.initialize();
+  }
+
+  Future<void> speak(String text) async {
+    await _tts.speak(text);
+  }
+
+  Future<void> listen(Function(String) onResult) async {
+    await _speech.listen(onResult: (result) {
+      if (result.finalResult) {
+        onResult(result.recognizedWords);
+      }
+    });
+  }
+
+  void stop() {
+    _speech.stop();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,122 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'features/home/home_page.dart';
+import 'services/supabase_service.dart';
 
-void main() {
-  runApp(const MyApp());
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await SupabaseService().init();
+  runApp(const ProviderScope(child: MyApp()));
 }
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'MemoVox',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      home: const HomePage(),
     );
   }
 }

--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -1,0 +1,20 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+import '../core/env.dart';
+
+class SupabaseService {
+  static final SupabaseService _instance = SupabaseService._internal();
+
+  factory SupabaseService() => _instance;
+
+  SupabaseService._internal();
+
+  Future<void> init() async {
+    await Env.load();
+    await Supabase.initialize(
+      url: Env.supabaseUrl,
+      anonKey: Env.supabaseAnonKey,
+    );
+  }
+
+  SupabaseClient get client => Supabase.instance.client;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,12 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  supabase_flutter: ^2.2.0
+  flutter_dotenv: ^5.0.2
+  speech_to_text: ^6.1.1
+  flutter_tts: ^3.7.0
+  flutter_local_notifications: ^16.1.0
+  flutter_riverpod: ^2.4.0
 
 dev_dependencies:
   flutter_test:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,12 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:memovox/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+  testWidgets('App builds', (WidgetTester tester) async {
+    await tester.pumpWidget(const ProviderScope(child: MyApp()));
+    expect(find.byType(MaterialApp), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add Supabase initialization and task CRUD scaffolding
- show tasks in a simple HomePage
- document the initial feature set in the README
- update widget test to smoke test app build

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687669c5b3cc832dab62954eb3e59259