### PR TITLE
Add theming and profile settings

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:intl/date_symbol_data_local.dart';
 import 'package:memovox/routes.dart';
 import 'package:memovox/services/auth_service.dart';
 import 'package:memovox/services/notification_service.dart';
+import 'package:memovox/services/theme_service.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 void main() async {
@@ -16,26 +17,43 @@ void main() async {
   final isAuthenticated = await AuthService.isAuthenticated();
   await initializeDateFormatting();
   await NotificationService.init();
+  themeController = ThemeController();
+  await themeController.loadTheme();
   runApp(Memovox(initialRoute: isAuthenticated ? '/today' : '/'));
 }
 
 // It's handy to then extract the Supabase client in a variable for later uses
 final supabase = Supabase.instance.client;
+late ThemeController themeController;
 
 class Memovox extends StatelessWidget {
   final String initialRoute;
-  
+
   const Memovox({super.key, required this.initialRoute});
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'MemoVox',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      initialRoute: initialRoute,
-      routes: routes,
+    return ValueListenableBuilder<ThemeMode>(
+      valueListenable: themeController,
+      builder: (context, mode, _) {
+        return MaterialApp(
+          title: 'MemoVox',
+          theme: ThemeData(
+            colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+            brightness: Brightness.light,
+          ),
+          darkTheme: ThemeData(
+            brightness: Brightness.dark,
+            colorScheme: ColorScheme.fromSeed(
+              seedColor: Colors.deepPurple,
+              brightness: Brightness.dark,
+            ),
+          ),
+          themeMode: mode,
+          initialRoute: initialRoute,
+          routes: routes,
+        );
+      },
     );
   }
 }

--- a/lib/pages/user/ProfilePage.dart
+++ b/lib/pages/user/ProfilePage.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:memovox/core/layout/AppDrawer.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 class ProfilePage extends StatefulWidget {
   const ProfilePage({super.key});
@@ -9,6 +10,36 @@ class ProfilePage extends StatefulWidget {
 }
 
 class _ProfilePageState extends State<ProfilePage> {
+  final _nameController = TextEditingController();
+  final _phoneController = TextEditingController();
+  final _emailController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    final user = Supabase.instance.client.auth.currentUser;
+    _nameController.text = user?.userMetadata?['full_name'] ?? '';
+    _phoneController.text = user?.phone ?? '';
+    _emailController.text = user?.email ?? '';
+  }
+
+  Future<void> _save() async {
+    final client = Supabase.instance.client;
+    try {
+      await client.auth.updateUser(UserAttributes(
+        data: {'full_name': _nameController.text},
+        phone: _phoneController.text.isEmpty ? null : _phoneController.text,
+      ));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Profil mis \u00e0 jour')),
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Erreur : $e')),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -27,20 +58,34 @@ class _ProfilePageState extends State<ProfilePage> {
               style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 20),
-            ListTile(
-              leading: const Icon(Icons.person),
-              title: const Text('Prénom Nom'),
-              subtitle: const Text('John Doe'),
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(
+                labelText: 'Nom complet',
+                prefixIcon: Icon(Icons.person),
+              ),
             ),
-            ListTile(
-              leading: const Icon(Icons.email),
-              title: const Text('Email'),
-              subtitle: const Text('john.doe@example.com'),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _emailController,
+              enabled: false,
+              decoration: const InputDecoration(
+                labelText: 'Email',
+                prefixIcon: Icon(Icons.email),
+              ),
             ),
-            ListTile(
-              leading: const Icon(Icons.phone),
-              title: const Text('Téléphone'),
-              subtitle: const Text('+1234567890'),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _phoneController,
+              decoration: const InputDecoration(
+                labelText: 'Téléphone',
+                prefixIcon: Icon(Icons.phone),
+              ),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _save,
+              child: const Text('Sauvegarder'),
             ),
           ],
         ),

--- a/lib/pages/user/SettingsPage.dart
+++ b/lib/pages/user/SettingsPage.dart
@@ -1,8 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:memovox/core/layout/AppDrawer.dart';
+import 'package:memovox/services/theme_service.dart';
 
-class SettingsPage extends StatelessWidget {
+class SettingsPage extends StatefulWidget {
   const SettingsPage({super.key});
+
+  @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  bool _darkMode = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _darkMode = themeController.value == ThemeMode.dark;
+  }
+
+  void _toggle(bool value) {
+    setState(() => _darkMode = value);
+    themeController.toggleTheme(value);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -12,8 +31,14 @@ class SettingsPage extends StatelessWidget {
         backgroundColor: Colors.indigo,
       ),
       drawer: const AppDrawer(),
-      body: const Center(
-        child: Text('Page de paramètres'),
+      body: ListView(
+        children: [
+          SwitchListTile(
+            title: const Text('Mode sombre'),
+            value: _darkMode,
+            onChanged: _toggle,
+          ),
+        ],
       ),
     );
   }

--- a/lib/services/theme_service.dart
+++ b/lib/services/theme_service.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ThemeController extends ValueNotifier<ThemeMode> {
+  static const _prefKey = 'themeMode';
+
+  ThemeController() : super(ThemeMode.light);
+
+  Future<void> loadTheme() async {
+    final prefs = await SharedPreferences.getInstance();
+    final isDark = prefs.getBool(_prefKey) ?? false;
+    value = isDark ? ThemeMode.dark : ThemeMode.light;
+  }
+
+  Future<void> toggleTheme(bool isDark) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_prefKey, isDark);
+    value = isDark ? ThemeMode.dark : ThemeMode.light;
+  }
+}

--- a/test/theme_service_test.dart
+++ b/test/theme_service_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memovox/services/theme_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ThemeController', () {
+    late ThemeController controller;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      controller = ThemeController();
+    });
+
+    test('initial load defaults to light', () async {
+      await controller.loadTheme();
+      expect(controller.value, ThemeMode.light);
+    });
+
+    test('toggleTheme saves preference', () async {
+      await controller.toggleTheme(true);
+      expect(controller.value, ThemeMode.dark);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool('themeMode'), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `ThemeController` service
- integrate dark mode in `MaterialApp`
- update profile and settings pages
- test theme service

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a6dbc4434832da052e71c22498b21