### PR TITLE
Fix AddItemMenu callback handling

### DIFF
--- a/lib/pages/user/TodayPage.dart
+++ b/lib/pages/user/TodayPage.dart
@@ -182,7 +182,11 @@ class _TodayPageState extends State<TodayPage>
   Future<void> _showAddItemMenu() async {
     final result = await showDialog<Map<String, dynamic>>(
       context: context,
-      builder: (context) => const AddItemMenu(),
+      builder: (context) => AddItemMenu(
+        onItemSelected: (type, method) {
+          Navigator.of(context).pop({'type': type, 'method': method});
+        },
+      ),
     );
 
     if (result == null) return;

--- a/lib/widgets/AddItemMenu.dart
+++ b/lib/widgets/AddItemMenu.dart
@@ -197,7 +197,6 @@ class _AddItemMenuState extends State<AddItemMenu>
             Expanded(
               child: TextButton.icon(
                 onPressed: () {
-                  Navigator.pop(context);
                   widget.onItemSelected?.call('task', 'quick');
                 },
                 icon: const Icon(Icons.add_circle_outline),


### PR DESCRIPTION
## Summary
- return selection results from `AddItemMenu`
- ensure quick actions trigger the callback

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d8eedb1cc832db56438aa0d60cf6f